### PR TITLE
aes.py: support pycryptodome

### DIFF
--- a/python/aes.py
+++ b/python/aes.py
@@ -28,10 +28,10 @@ class AES(cipher.Blockcipher):
 
     def encrypt(self, pt, key):
         assert len(key) == self.lengths()['key']
-        a = Crypto.Cipher.AES.new(key)
+        a = Crypto.Cipher.AES.new(key, Crypto.Cipher.AES.MODE_ECB)
         return a.encrypt(pt)
 
     def decrypt(self, ct, key):
         assert len(key) == self.lengths()['key']
-        a = Crypto.Cipher.AES.new(key)
+        a = Crypto.Cipher.AES.new(key, Crypto.Cipher.AES.MODE_ECB)
         return a.decrypt(ct)


### PR DESCRIPTION
'pycryptodome', which is the replacement for the unmaintained
'pycrypto', requires that the mode be passed to Crypto.Cipher.AES.new()
rather than defaulting to ECB mode.  Specify the mode explicitly to be
compatible with both packages.