### PR TITLE
More build and CI fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
     - name: Install dependencies
       run: |
         sudo apt-get update
-        sudo apt-get install -y python3 python3-crypto
+        sudo apt-get install -y python3 python3-pycryptodome
     - name: Test python code
       run: |
         ./python/run_tests check

--- a/benchmark/src/cipher_benchmark_template.h
+++ b/benchmark/src/cipher_benchmark_template.h
@@ -7,12 +7,12 @@
  */
 {
 	const size_t bufsize = g_params.bufsize;
-	u8 *orig = malloc(bufsize);
-	u8 *ctext = malloc(bufsize);
+	u8 *orig = calloc(1, bufsize);
+	u8 *ctext = calloc(1, bufsize);
 #ifdef ENCRYPT_SIMD
-	u8 *ctext_simd = malloc(bufsize);
+	u8 *ctext_simd = calloc(1, bufsize);
 #endif
-	u8 *ptext = malloc(bufsize);
+	u8 *ptext = calloc(1, bufsize);
 	u8 key[KEY_BYTES];
 	u8 orig_iv[IV_BYTES];
 	u8 iv[IV_BYTES];

--- a/benchmark/src/util.h
+++ b/benchmark/src/util.h
@@ -77,19 +77,15 @@ __cold __noreturn void assertion_failed(const char *expr,
 
 #ifdef __CHECKER__
 #define __force		__attribute__((force))
-#define __bitwise__	__attribute__((bitwise))
 #else
 #define __force
-#define __bitwise__
 #endif
 
-#if !defined(__linux__)
-
-typedef u32 __bitwise__ __le32;
-typedef u64 __bitwise__ __le64;
-typedef u32 __bitwise__ __be32;
-typedef u64 __bitwise__ __be64;
-
+#ifndef __linux__
+typedef u32 __le32;
+typedef u64 __le64;
+typedef u32 __be32;
+typedef u64 __be64;
 #endif
 
 #define cpu_to_le32(v)	((__force __le32)(u32)(v))

--- a/python/aes.py
+++ b/python/aes.py
@@ -4,7 +4,7 @@
 # license that can be found in the LICENSE file or at
 # https://opensource.org/licenses/MIT.
 
-import Crypto.Cipher.AES
+import Cryptodome.Cipher.AES
 
 import cipher
 
@@ -28,10 +28,10 @@ class AES(cipher.Blockcipher):
 
     def encrypt(self, pt, key):
         assert len(key) == self.lengths()['key']
-        a = Crypto.Cipher.AES.new(key, Crypto.Cipher.AES.MODE_ECB)
+        a = Cryptodome.Cipher.AES.new(key, Cryptodome.Cipher.AES.MODE_ECB)
         return a.encrypt(pt)
 
     def decrypt(self, ct, key):
         assert len(key) == self.lengths()['key']
-        a = Crypto.Cipher.AES.new(key, Crypto.Cipher.AES.MODE_ECB)
+        a = Cryptodome.Cipher.AES.new(key, Cryptodome.Cipher.AES.MODE_ECB)
         return a.decrypt(ct)


### PR DESCRIPTION
* benchmark: fix build warning with latest <linux/types.h>
* benchmark: fix another -Wmaybe-uninitialized warning
* Explicitly use pycryptodome instead of pycrypto